### PR TITLE
enable `minted` package for code highlighting

### DIFF
--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -4,10 +4,13 @@ RUN apt-get update && apt-get install -y \
   wget \
   git \
   make \
-  texlive-full && \
+  texlive-full \ 
+  texlive-latex-extra \
+  python \
+  python-pip \
+  python-pygments && \
   # Removing documentation packages *after* installing them is kind of hacky,
   # but it only adds some overhead while building the image.
   apt-get --purge remove -y .\*-doc$ && \
   # Remove more unnecessary stuff
   apt-get clean -y
-


### PR DESCRIPTION
influenced by the idea from https://github.com/vvhof/minted-latex-docker to add `minted` package to the image.

I have tested the changes:
1. by publishing the image: `docker pull akolotov/latex`
2. by including the image into https://gitlab.com/project-oriented-challenges/onti-irs-201718-assignements/blob/master/.gitlab-ci.yml
