### PR TITLE
Add pandoc conversion tool

### DIFF
--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y \
   wget \
   git \
   make \
-  texlive-full \ 
+  texlive-full \
+  # markup format conversion tool
+  pandoc \
   # Required for syntax highlighting using minted.
   python-pygments && \
   # Removing documentation packages *after* installing them is kind of hacky,


### PR DESCRIPTION
[Pandoc](http://pandoc.org/) is a swiss-army knife for markup format conversion
and commonly used for converting markdown to latex or pdf, for instance.
Adding pandoc only adds about 50MB to the uncompressed image size

```
$ docker image ls
REPOSITORY                          TAG                 IMAGE ID            CREATED              SIZE
jacksgt/latex                       latest              bc84a67dba2c        About a minute ago   4.2GB
aergus/latex                        latest              f2150bd23f38        About an hour ago    4.15GB
```