### PR TITLE
switch from python-pygments to python3-pygments

### DIFF
--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -16,7 +16,7 @@ ARG WGET=wget
 ARG GIT=git
 ARG MAKE=make
 ARG PANDOC=pandoc
-ARG PYGMENTS=python-pygments
+ARG PYGMENTS=python3-pygments
 ARG FIG2DEV=fig2dev
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Fixes the issue I decribed here: https://gitlab.com/aergus/dockerfiles/issues/2 (tl;dr minted does no longer work)

It seams like the maintainers at debian removed the wrapper `/usr/bin/pygmentize` from the package `python-pygments`, but it is now available in `python3-pygments`.
This broke minted.

My forked version is available on docker hub for everyone with the same problem (until this gets merged): https://hub.docker.com/r/phil9909/latex/
